### PR TITLE
Trust anchors parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,14 +46,14 @@ ext{
     ]
 
     libVersions = [
-        junit: '4.12',
+        junit: '4.13',
         mockito : [
                 android: '1.10.19'
         ],
         dexmaker : '1.4',
         androidx : [
-            annotation: '1.0.0',
-            test: '1.1.0',
+            annotation: '1.1.0',
+            test: '1.3.0',
             legacySupport: '1.0.0',
             appcompat: '1.0.2',
             preference: '1.0.0'

--- a/trustkit/build.gradle
+++ b/trustkit/build.gradle
@@ -28,7 +28,6 @@ repositories {
 dependencies {
     implementation "androidx.annotation:annotation:$rootProject.libVersions.androidx.annotation"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.libVersions.androidx.legacySupport"
-    implementation "androidx.preference:preference:$rootProject.libVersions.androidx.preference"
     compileOnly "com.squareup.okhttp3:okhttp:$rootProject.libVersions.squareup.okhttp3"
     compileOnly "com.squareup.okhttp:okhttp:$rootProject.libVersions.squareup.okhttp2"
 

--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
@@ -34,8 +34,8 @@ public class DomainPinningPolicyTest {
         // Given a valid policy for a domain
         // When parsing it, it succeeds
         DomainPinningPolicy policy = new DomainPinningPolicy(
-                "www.test.com", true, pins, true, date, reportUris, false
-        );
+                "www.test.com", true, pins, true, date, reportUris, false,
+        null);
         // And the right configuration was saved
         assertEquals("www.test.com", policy.getHostname());
         assertEquals(date, policy.getExpirationDate());
@@ -66,8 +66,7 @@ public class DomainPinningPolicyTest {
 
         // When parsing it, it succeeds
         DomainPinningPolicy policy = new DomainPinningPolicy(
-                internationalDomain, true, pins, true, date, reportUris, false
-        );
+                internationalDomain, true, pins, true, date, reportUris, false, null);
         assertEquals(policy.getHostname(), internationalDomain);
         assertEquals(policy.getHostname(), "českárepublika.icom.museum");
     }
@@ -81,7 +80,7 @@ public class DomainPinningPolicyTest {
         // When parsing it, it fails
         boolean didReceiveConfigError = false;
         try {
-            new DomainPinningPolicy("www.test.com", true, badPins, true, date, reportUris, false);
+            new DomainPinningPolicy("www.test.com", true, badPins, true, date, reportUris, false, null);
         } catch (ConfigurationException e) {
             if (e.getMessage().startsWith("Less than two pins")) {
                 didReceiveConfigError = true;
@@ -101,7 +100,7 @@ public class DomainPinningPolicyTest {
 
         // When parsing it, it fails
         try {
-            new DomainPinningPolicy("www.test.com", true, emptyPins, true, date, reportUris, false);
+            new DomainPinningPolicy("www.test.com", true, emptyPins, true, date, reportUris, false, null);
         } catch (ConfigurationException e) {
             if (e.getMessage().startsWith("An empty pin-set")) {
                 didReceivedConfigError = true;
@@ -120,7 +119,7 @@ public class DomainPinningPolicyTest {
         // When parsing it, it fails
         boolean didReceiveConfigError = false;
         try {
-            new DomainPinningPolicy(badDomain, true, pins, true, date, reportUris, false);
+            new DomainPinningPolicy(badDomain, true, pins, true, date, reportUris, false, null);
         }
         catch (ConfigurationException e) {
             if (e.getMessage().startsWith("Tried to pin an invalid domain")) {

--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
@@ -1,6 +1,8 @@
 package com.datatheorem.android.trustkit.config;
 
 
+import com.datatheorem.android.trustkit.TrustKit;
+
 import org.junit.Test;
 
 import java.net.MalformedURLException;
@@ -10,6 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 
@@ -112,7 +115,8 @@ public class DomainPinningPolicyTest {
     }
 
     @Test
-    public void testBadPolicyPinTld() throws MalformedURLException {
+    public void testBadPolicyPinTldError() throws MalformedURLException {
+        TrustKit.failOnInvalidDomain = true;
         // Given a policy for an invalid domain
         String badDomain = ".com";
 
@@ -129,5 +133,26 @@ public class DomainPinningPolicyTest {
             }
         }
         assertTrue(didReceiveConfigError);
+    }
+
+    @Test
+    public void testBadPolicyPinTldWarning() throws MalformedURLException {
+        TrustKit.failOnInvalidDomain = false;
+        // Given a policy for an invalid domain
+        String badDomain = ".com";
+
+        // When parsing it, it fails
+        boolean didReceiveConfigError = false;
+        try {
+            new DomainPinningPolicy(badDomain, true, pins, true, date, reportUris, false, null);
+        }
+        catch (ConfigurationException e) {
+            if (e.getMessage().startsWith("Tried to pin an invalid domain")) {
+                didReceiveConfigError = true;
+            } else {
+                throw e;
+            }
+        }
+        assertFalse(didReceiveConfigError);
     }
 }

--- a/trustkit/src/androidTest/res/xml/network_security_config.xml
+++ b/trustkit/src/androidTest/res/xml/network_security_config.xml
@@ -18,7 +18,7 @@
         <pin-set>
             <!-- Pin the Leaf key -->
             <pin digest="SHA-256">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</pin>
-            <pin digest="SHA-256">u91x/rv9ivMrXO0du6N2ABI6BiiVfD0T99DTEzoqSv4=</pin>
+            <pin digest="SHA-256">a4FoHyEnsFhauIx0w/gB7ywslD6tWGk83J2F6Pv1phA=</pin>
         </pin-set>
         <trustkit-config enforcePinning="true">
         </trustkit-config>

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
@@ -30,20 +30,19 @@ import javax.net.ssl.X509TrustManager;
 
 import androidx.annotation.NonNull;
 
-
 /**
  * Class that provides all of the TrustKit public APIs.
  *
  * <p>
- *     It should be used to initialize the App's SSL pinning policy and to retrieve the
- *     corresponding {@code SSLSocketFactory} and {@code X509TrustManager}, to be used to add SSL
- *     pinning validation to the App's network connections.
+ * It should be used to initialize the App's SSL pinning policy and to retrieve the
+ * corresponding {@code SSLSocketFactory} and {@code X509TrustManager}, to be used to add SSL
+ * pinning validation to the App's network connections.
  * </p>
  *
  * <p>
- *     TrustKit works by extending the
- *     <a href="https://developer.android.com/training/articles/security-config.html" target="_blank">
- *         Android N Network Security Configuration</a> in two ways:
+ * TrustKit works by extending the
+ * <a href="https://developer.android.com/training/articles/security-config.html" target="_blank">
+ * Android N Network Security Configuration</a> in two ways:
  *
  *     <ul>
  *         <li>It provides support for the SSL pinning functionality of the Android N Network
@@ -57,7 +56,7 @@ import androidx.annotation.NonNull;
  *             Public Key Pinning</a> and <a href="https://github.com/datatheorem/trustkit" target="_blank">TrustKit
  *             iOS</a>.</li>
  *     </ul>
- *
+ * <p>
  *     For better compatibility, TrustKit will also run on API levels 15 and 16 but its
  *     functionality will be disabled.
  * </p>
@@ -83,9 +82,9 @@ import androidx.annotation.NonNull;
  *     {@code system} values will be ignored).</li>
  * </ul>
  *
- *<p>
+ * <p>
  *     On Android N devices, the OS' implementation is used and all XML tags are supported.
- *</p>
+ * </p>
  *
  * <h3>Additional TrustKit Settings</h3>
  *
@@ -122,7 +121,7 @@ import androidx.annotation.NonNull;
  *     </ul>
  *
  * <h4>{@code <report-uri>}</h4>
- *
+ * <p>
  *     A URL to which pin validation failures should be reported, to be defined within a
  *     {@code <trustkit-config>} tag. The format of the reports is similar to the one described in
  *     <a href="https://tools.ietf.org/html/rfc7469#section-2.1.4" target="_blank">RFC 7469 for the HPKP
@@ -167,7 +166,6 @@ import androidx.annotation.NonNull;
  *         </network-security-config>
  *     }
  * </pre>
- *
  */
 public class TrustKit {
 
@@ -176,21 +174,18 @@ public class TrustKit {
     private final TrustKitConfiguration trustKitConfiguration;
 
     protected TrustKit(@NonNull Context context,
-                       @NonNull TrustKitConfiguration trustKitConfiguration) {
+        @NonNull TrustKitConfiguration trustKitConfiguration) {
         this.trustKitConfiguration = trustKitConfiguration;
 
         // Setup the debug-overrides setting if the App is debuggable
         // Do not use BuildConfig.DEBUG as it does not work for libraries
         boolean isAppDebuggable = (0 !=
-                (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
+            (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE));
         Set<Certificate> debugCaCerts = null;
-        boolean shouldOverridePins = false;
-        if (isAppDebuggable) {
-            debugCaCerts = trustKitConfiguration.getDebugCaCertificates();
-            if (debugCaCerts != null) {
-                TrustKitLog.i("App is debuggable - processing <debug-overrides> configuration.");
-            }
-            shouldOverridePins = trustKitConfiguration.shouldOverridePins();
+        boolean shouldOverridePins = trustKitConfiguration.shouldOverridePins();
+        debugCaCerts = trustKitConfiguration.getDebugCaCertificates();
+        if (isAppDebuggable && debugCaCerts != null) {
+            TrustKitLog.i("App is debuggable - processing <debug-overrides> configuration.");
         }
 
         // Create the background reporter for sending pin failure reports
@@ -198,7 +193,6 @@ public class TrustKit {
         String appVersion;
         try {
             appVersion = context.getPackageManager().getPackageInfo(appPackageName, 0).versionName;
-
         } catch (PackageManager.NameNotFoundException e) {
             appVersion = "N/A";
         }
@@ -209,20 +203,21 @@ public class TrustKit {
 
         String appVendorId = VendorIdentifier.getOrCreate(context);
         BackgroundReporter reporter = new BackgroundReporter(context, appPackageName, appVersion,
-                appVendorId);
+            appVendorId);
 
         // Initialize the trust manager builder
         try {
             TrustManagerBuilder.initializeBaselineTrustManager(debugCaCerts,
-                    shouldOverridePins, reporter);
+                shouldOverridePins, reporter);
         } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException
-                | IOException e) {
+            | IOException e) {
             throw new ConfigurationException("Could not parse <debug-overrides> certificates");
         }
     }
 
-    /** Try to retrieve the Network Security Policy resource ID configured in the App's manifest.
-     *
+    /**
+     * Try to retrieve the Network Security Policy resource ID configured in the App's manifest.
+     * <p>
      * Somewhat convoluted as other means of getting the resource ID involve using private APIs.
      *
      * @param context
@@ -234,6 +229,7 @@ public class TrustKit {
 
         // Dump the content of the ApplicationInfo, which contains the resource ID on Android N
         class NetSecConfigResIdRetriever implements Printer {
+
             private int netSecConfigResourceId = -1;
             private final String NETSEC_LINE_FORMAT = "networkSecurityConfigRes=0x";
 
@@ -242,12 +238,14 @@ public class TrustKit {
                     // Attempt at parsing "networkSecurityConfigRes=0x1234"
                     if (x.contains(NETSEC_LINE_FORMAT)) {
                         netSecConfigResourceId =
-                                Integer.parseInt(x.substring(NETSEC_LINE_FORMAT.length()), 16);
+                            Integer.parseInt(x.substring(NETSEC_LINE_FORMAT.length()), 16);
                     }
                 }
             }
 
-            private int getNetworkSecurityConfigResId() { return netSecConfigResourceId; }
+            private int getNetworkSecurityConfigResId() {
+                return netSecConfigResourceId;
+            }
         }
 
         NetSecConfigResIdRetriever retriever = new NetSecConfigResIdRetriever();
@@ -255,36 +253,38 @@ public class TrustKit {
         return retriever.getNetworkSecurityConfigResId();
     }
 
-    /** Initialize TrustKit with the Network Security Configuration file at the default location
+    /**
+     * Initialize TrustKit with the Network Security Configuration file at the default location
      * res/xml/network_security_config.xml. The Network Security Configuration file must also have
      * been <a href="https://developer.android.com/training/articles/security-config.html#manifest" target="_blank">
-     *     added to the App's manifest</a>.
+     * added to the App's manifest</a>.
      *
      * @param context the application's context.
      * @throws ConfigurationException if the policy could not be parsed or contained errors.
      */
     @NonNull
     public synchronized static TrustKit initializeWithNetworkSecurityConfiguration(
-            @NonNull Context context) {
+        @NonNull Context context) {
         // Try to get the default network policy resource ID
         int networkSecurityConfigId = context.getResources().getIdentifier(
-                "network_security_config", "xml", context.getPackageName());
+            "network_security_config", "xml", context.getPackageName());
         return initializeWithNetworkSecurityConfiguration(context, networkSecurityConfigId);
     }
 
-    /** Initialize TrustKit with the Network Security Configuration file with the specified
+    /**
+     * Initialize TrustKit with the Network Security Configuration file with the specified
      * resource ID. The Network Security Configuration file must also have
      * been <a href="https://developer.android.com/training/articles/security-config.html#manifest" target="_blank">
-     *     added to the App's manifest</a>.
+     * added to the App's manifest</a>.
      *
-     * @param context the application's context.
+     * @param context                 the application's context.
      * @param configurationResourceId the resource ID for the Network Security Configuration file to
      *                                use.
      * @throws ConfigurationException if the policy could not be parsed or contained errors.
      */
     @NonNull
     public synchronized static TrustKit initializeWithNetworkSecurityConfiguration(
-            @NonNull Context context, int configurationResourceId) {
+        @NonNull Context context, int configurationResourceId) {
         if (trustKitInstance != null) {
             throw new IllegalStateException("TrustKit has already been initialized");
         }
@@ -297,12 +297,11 @@ public class TrustKit {
                 // Android did not find a policy because the supplied resource ID is wrong or the
                 // policy file is not properly setup in the manifest, or contains bad data
                 throw new ConfigurationException("TrustKit was initialized with a network policy " +
-                        "that was not properly configured for Android N - make sure it is in the " +
-                        "App's Manifest.");
-            }
-            else if (systemConfigResId != configurationResourceId) {
+                    "that was not properly configured for Android N - make sure it is in the " +
+                    "App's Manifest.");
+            } else if (systemConfigResId != configurationResourceId) {
                 throw new ConfigurationException("TrustKit was initialized with a different " +
-                        "network policy than the one configured in the App's manifest.");
+                    "network policy than the one configured in the App's manifest.");
             }
         }
 
@@ -310,20 +309,21 @@ public class TrustKit {
         TrustKitConfiguration trustKitConfiguration;
         try {
             trustKitConfiguration = TrustKitConfiguration.fromXmlPolicy(
-                    context, context.getResources().getXml(configurationResourceId)
+                context, context.getResources().getXml(configurationResourceId)
             );
         } catch (XmlPullParserException | IOException e) {
             throw new ConfigurationException("Could not parse network security policy file");
         } catch (CertificateException e) {
             throw new ConfigurationException("Could not find the debug certificate in the " +
-                    "network security police file");
+                "network security police file");
         }
 
         trustKitInstance = new TrustKit(context, trustKitConfiguration);
         return trustKitInstance;
     }
 
-    /** Retrieve the initialized instance of TrustKit.
+    /**
+     * Retrieve the initialized instance of TrustKit.
      *
      * @throws IllegalStateException if TrustKit has not been initialized.
      */
@@ -335,24 +335,27 @@ public class TrustKit {
         return trustKitInstance;
     }
 
-    /** Retrieve the current TrustKit configuration.
-     *
+    /**
+     * Retrieve the current TrustKit configuration.
      */
     @NonNull
-    public TrustKitConfiguration getConfiguration() { return trustKitConfiguration; }
-    
-    /** Retrieve an {@code SSLSSocketFactory} that implements SSL pinning validation based on the
+    public TrustKitConfiguration getConfiguration() {
+        return trustKitConfiguration;
+    }
+
+    /**
+     * Retrieve an {@code SSLSSocketFactory} that implements SSL pinning validation based on the
      * current TrustKit configuration for the specified serverHostname. It can be used with most
      * network APIs (such as {@code HttpsUrlConnection}) to add SSL pinning validation to the
      * connections.
      *
      * <p>
-     *     The {@code SSLSocketFactory} is configured for the supplied serverHostname, and will
-     *     enforce this domain's pinning policy even if a redirection to a different domain occurs
-     *     during the connection. Hence validation will always fail in the case of a redirection to
-     *     a different domain.
-     *     However, pinning validation is only meant to be used on the App's API server(s), and
-     *     redirections to other domains should not happen in this scenario.
+     * The {@code SSLSocketFactory} is configured for the supplied serverHostname, and will
+     * enforce this domain's pinning policy even if a redirection to a different domain occurs
+     * during the connection. Hence validation will always fail in the case of a redirection to
+     * a different domain.
+     * However, pinning validation is only meant to be used on the App's API server(s), and
+     * redirections to other domains should not happen in this scenario.
      * </p>
      *
      * @param serverHostname the server's hostname that the {@code SSLSocketFactory} will be used to
@@ -363,7 +366,7 @@ public class TrustKit {
     public SSLSocketFactory getSSLSocketFactory(@NonNull String serverHostname) {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[]{getTrustManager(serverHostname)}, null);
+            sslContext.init(null, new TrustManager[] {getTrustManager(serverHostname)}, null);
 
             return sslContext.getSocketFactory();
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -372,18 +375,18 @@ public class TrustKit {
         }
     }
 
-
-    /** Retrieve an {@code X509TrustManager} that implements SSL pinning validation based on the
+    /**
+     * Retrieve an {@code X509TrustManager} that implements SSL pinning validation based on the
      * current TrustKit configuration for the supplied hostname. It can be used with some network
      * APIs that let developers supply a trust manager to customize SSL validation.
      *
      * <p>
-     *     The {@code X509TrustManager} is configured for the supplied serverHostname, and will
-     *     enforce this domain's pinning policy even if a redirection to a different domain occurs
-     *     during the connection. Hence validation will always fail in the case of a redirection to
-     *     a different domain.
-     *     However, pinning validation is only meant to be used on the App's API server(s), and
-     *     redirections to other domains should not happen in this scenario.
+     * The {@code X509TrustManager} is configured for the supplied serverHostname, and will
+     * enforce this domain's pinning policy even if a redirection to a different domain occurs
+     * during the connection. Hence validation will always fail in the case of a redirection to
+     * a different domain.
+     * However, pinning validation is only meant to be used on the App's API server(s), and
+     * redirections to other domains should not happen in this scenario.
      * </p>
      *
      * @param serverHostname the server's hostname that the {@code X509TrustManager} will be used to

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import androidx.annotation.NonNull;
 import android.util.Printer;
 
 import com.datatheorem.android.trustkit.config.ConfigurationException;
@@ -28,6 +27,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import androidx.annotation.NonNull;
 
 
 /**

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
@@ -170,6 +170,7 @@ import androidx.annotation.NonNull;
 public class TrustKit {
 
     protected static TrustKit trustKitInstance;
+    public static boolean failOnInvalidDomain = true;
 
     private final TrustKitConfiguration trustKitConfiguration;
 
@@ -291,9 +292,28 @@ public class TrustKit {
     @NonNull
     public synchronized static TrustKit initializeWithNetworkSecurityConfiguration(
         @NonNull Context context, int configurationResourceId) {
+        return initializeWithNetworkSecurityConfiguration(context, configurationResourceId, true);
+    }
+
+    /**
+     * Initialize TrustKit with the Network Security Configuration file with the specified
+     * resource ID. The Network Security Configuration file must also have
+     * been <a href="https://developer.android.com/training/articles/security-config.html#manifest" target="_blank">
+     * added to the App's manifest</a>.
+     *
+     * @param context                 the application's context.
+     * @param configurationResourceId the resource ID for the Network Security Configuration file to
+     *                                use.
+     * @throws ConfigurationException if the policy could not be parsed or contained errors.
+     */
+    @NonNull
+    public synchronized static TrustKit initializeWithNetworkSecurityConfiguration(
+        @NonNull Context context, int configurationResourceId, boolean failOnInvalidDomain) {
         if (trustKitInstance != null) {
             throw new IllegalStateException("TrustKit has already been initialized");
         }
+
+        TrustKit.failOnInvalidDomain = failOnInvalidDomain;
 
         // On Android N, ensure that the system was also able to load the policy
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
@@ -1,5 +1,6 @@
 package com.datatheorem.android.trustkit.config;
 
+import com.datatheorem.android.trustkit.TrustKit;
 import com.datatheorem.android.trustkit.utils.TrustKitLog;
 
 import java.net.MalformedURLException;
@@ -49,7 +50,11 @@ public final class DomainPinningPolicy {
         // Check if the hostname seems valid
         DomainValidator domainValidator = DomainValidator.getInstance();
         if (!domainValidator.isValid(hostname)) {
-            TrustKitLog.w("Tried to pin an invalid domain: " + hostname);
+            if (TrustKit.failOnInvalidDomain) {
+                throw new ConfigurationException("Tried to pin an invalid domain: " + hostname);
+            } else {
+                TrustKitLog.w("Tried to pin an invalid domain: " + hostname);
+            }
         }
         this.hostname = hostname.trim();
 

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
@@ -1,13 +1,16 @@
 package com.datatheorem.android.trustkit.config;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import com.datatheorem.android.trustkit.utils.TrustKitLog;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 
 public final class DomainPinningPolicy {
@@ -43,7 +46,7 @@ public final class DomainPinningPolicy {
         // Check if the hostname seems valid
         DomainValidator domainValidator = DomainValidator.getInstance();
         if (!domainValidator.isValid(hostname)) {
-            throw new ConfigurationException("Tried to pin an invalid domain: " + hostname);
+            TrustKitLog.w("Tried to pin an invalid domain: " + hostname);
         }
         this.hostname = hostname.trim();
 

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
@@ -2,6 +2,7 @@ package com.datatheorem.android.trustkit.config;
 
 import android.content.Context;
 
+import com.datatheorem.android.trustkit.TrustKit;
 import com.datatheorem.android.trustkit.utils.TrustKitLog;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -99,8 +100,11 @@ public class TrustKitConfiguration {
         DomainValidator domainValidator = DomainValidator.getInstance(true);
 
         if (!domainValidator.isValid(serverHostname)) {
-            TrustKitLog.w("Invalid domain supplied: " + serverHostname);
-            //            throw new IllegalArgumentException("Invalid domain supplied: " + serverHostname);
+            if (TrustKit.failOnInvalidDomain) {
+                throw new IllegalArgumentException("Invalid domain supplied: " + serverHostname);
+            } else {
+                TrustKitLog.w("Invalid domain supplied: " + serverHostname);
+            }
         }
 
         DomainPinningPolicy bestMatchPolicy = null;

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
@@ -1,15 +1,20 @@
 package com.datatheorem.android.trustkit.config;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+
+import com.datatheorem.android.trustkit.utils.TrustKitLog;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
 import java.io.IOException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.HashSet;
 import java.util.Set;
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 
 public class TrustKitConfiguration {
@@ -84,7 +89,8 @@ public class TrustKitConfiguration {
         DomainValidator domainValidator = DomainValidator.getInstance(true);
 
         if (!domainValidator.isValid(serverHostname)) {
-            throw new IllegalArgumentException("Invalid domain supplied: " + serverHostname);
+            TrustKitLog.w("Invalid domain supplied: " + serverHostname);
+//            throw new IllegalArgumentException("Invalid domain supplied: " + serverHostname);
         }
 
         DomainPinningPolicy bestMatchPolicy = null;

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 public class TrustKitConfiguration {
 
     @NonNull private final Set<DomainPinningPolicy> domainPolicies;
+    @Nullable private final Set<Certificate> trustAnchorsCertificates;
 
     // For simplicity, this works slightly differently than Android N as we use shouldOverridePins
     // as a global setting instead of a per-<certificates> setting like Android N does
@@ -40,6 +41,7 @@ public class TrustKitConfiguration {
         boolean shouldOverridePins,
         @Nullable Set<Certificate> debugCaCerts
     ) {
+        Set<Certificate> certificates = new HashSet<>();
         Set<String> hostnameSet = new HashSet<>();
         for (DomainPinningPolicy domainConfig : domainConfigSet) {
             if (hostnameSet.contains(domainConfig.getHostname())) {
@@ -48,11 +50,12 @@ public class TrustKitConfiguration {
             }
             hostnameSet.add(domainConfig.getHostname());
 
-            // Override debug certs
-            if (debugCaCerts == null) {
-                debugCaCerts = domainConfig.getTrustAnchors();
+            if (domainConfig.getTrustAnchors() != null) {
+                certificates.addAll(domainConfig.getTrustAnchors());
             }
         }
+
+        this.trustAnchorsCertificates = certificates.isEmpty() ? null : certificates;
         this.domainPolicies = domainConfigSet;
         this.shouldOverridePins = shouldOverridePins;
         this.debugCaCertificates = debugCaCerts;
@@ -74,6 +77,11 @@ public class TrustKitConfiguration {
      */
     public Set<DomainPinningPolicy> getAllPolicies() {
         return this.domainPolicies;
+    }
+
+    @Nullable
+    public Set<Certificate> getTrustAnchorsCertificates() {
+        return trustAnchorsCertificates;
     }
 
     /**

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfigurationParser.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfigurationParser.java
@@ -111,7 +111,7 @@ class TrustKitConfigurationParser {
                         .setShouldEnforcePinning(trustkitTag.enforcePinning)
                         .setShouldDisableDefaultReportUri(trustkitTag.disableDefaultReportUri);
                 } else if ("trust-anchors".equals(parser.getName())) {
-                    Set<Certificate> trustAnchor = readTrustAnchor(context, parser);
+                    Set<Certificate> trustAnchor = readTrustAnchors(context, parser);
                     builder.setTrustAnchors(trustAnchor);
                 }
             }
@@ -242,10 +242,10 @@ class TrustKitConfigurationParser {
         Set<Certificate> debugCaCertificates = null;
     }
 
-    private static Set<Certificate> readTrustAnchor(@NonNull Context context, @NonNull XmlPullParser parser) throws CertificateException,
+    private static Set<Certificate> readTrustAnchors(@NonNull Context context, @NonNull XmlPullParser parser) throws CertificateException,
         IOException, XmlPullParserException {
         // Parse trust anchor
-        Set<Certificate> debugCaCertificates = new HashSet<>();
+        Set<Certificate> trustAnchorsCertificates = new HashSet<>();
 
         int eventType = parser.next();
         while (!((eventType == XmlPullParser.END_TAG) && "trust-anchors".equals(parser.getName()))) {
@@ -268,10 +268,10 @@ class TrustKitConfigurationParser {
                                 caPathFromUser.split("/")[1], "raw",
                                 context.getPackageName()));
 
-                    debugCaCertificates.add(CertificateFactory.getInstance("X.509")
+                    trustAnchorsCertificates.add(CertificateFactory.getInstance("X.509")
                         .generateCertificate(stream));
                 } else {
-                    TrustKitLog.i("No <debug-overrides> certificates found by TrustKit." +
+                    TrustKitLog.i("No <trust-anchors> certificates found by TrustKit." +
                         " Please check your @raw folder " +
                         "(TrustKit doesn't support system and user installed certificates).");
                 }
@@ -279,7 +279,7 @@ class TrustKitConfigurationParser {
             eventType = parser.next();
         }
 
-        return debugCaCertificates;
+        return trustAnchorsCertificates;
     }
 
     @NonNull

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/ExtendedTrustManager.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/ExtendedTrustManager.java
@@ -15,16 +15,15 @@ import javax.net.ssl.X509TrustManager;
 
 
 /**
- * Used when <debug-overrides> is enabled in the network security policy and we are on a pre-N
+ * Used when <debug-overrides> or <trust-anchors> is enabled in the network security policy and we are on a pre-N
  * Android device (as Android N automatically takes care of this). It returns a trust manager that
- * trusts the supplied debug CA certificates, in addition to the Android system and user CA
- * certificates.
+ * trusts the supplied debug CA certificates, in addition to the Android system and user CA certificates.
  */
-class DebugOverridesTrustManager {
+class ExtendedTrustManager {
 
-    public static X509TrustManager getInstance(Set<Certificate> debugCaCerts) throws
+    public static X509TrustManager getInstance(Set<Certificate> certificates) throws
             CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException {
-        X509TrustManager debugTrustManager = null;
+        X509TrustManager extendedTrustManager = null;
 
         // Create a KeyStore containing our trusted CAs and the Android user and system CAs
         KeyStore systemKeyStore = KeyStore.getInstance("AndroidCAStore");
@@ -39,9 +38,9 @@ class DebugOverridesTrustManager {
             keyStore.setCertificateEntry(alias , cert);
         }
 
-        // Add the extra debug CAs to the store
-        for (Certificate caCert : debugCaCerts) {
-            String alias = "debug: " + ((X509Certificate) caCert).getSubjectDN().getName();
+        // Add the extra CAs to the store
+        for (Certificate caCert : certificates) {
+            String alias = "anchor: " + ((X509Certificate) caCert).getSubjectDN().getName();
             keyStore.setCertificateEntry(alias , caCert);
         }
 
@@ -53,13 +52,13 @@ class DebugOverridesTrustManager {
 
         for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
             if (trustManager instanceof X509TrustManager) {
-                debugTrustManager = (X509TrustManager) trustManager;
+                extendedTrustManager = (X509TrustManager) trustManager;
             }
         }
 
-        if (debugTrustManager == null) {
+        if (extendedTrustManager == null) {
             throw new IllegalStateException("Should never happen");
         }
-        return debugTrustManager;
+        return extendedTrustManager;
     }
 }

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/TrustManagerBuilder.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/TrustManagerBuilder.java
@@ -1,18 +1,22 @@
 package com.datatheorem.android.trustkit.pinning;
 
 import android.os.Build;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+
 import com.datatheorem.android.trustkit.TrustKit;
 import com.datatheorem.android.trustkit.config.DomainPinningPolicy;
 import com.datatheorem.android.trustkit.reporting.BackgroundReporter;
+
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.Set;
+
 import javax.net.ssl.X509TrustManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 
 
@@ -27,7 +31,7 @@ public class TrustManagerBuilder {
     // The reporter that will send pinning failure reports
     protected static BackgroundReporter backgroundReporter = null;
 
-    public static void initializeBaselineTrustManager(@Nullable Set<Certificate> debugCaCerts,
+    public static void initializeBaselineTrustManager(@Nullable Set<Certificate> trustAnchors,
                                                       boolean debugOverridePins,
                                                       @NonNull BackgroundReporter reporter)
             throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
@@ -44,9 +48,9 @@ public class TrustManagerBuilder {
         }
 
         shouldOverridePins = debugOverridePins;
-        if ((debugCaCerts != null) && (debugCaCerts.size() > 0) && (Build.VERSION.SDK_INT < 24)) {
+        if ((trustAnchors != null) && (trustAnchors.size() > 0) && (Build.VERSION.SDK_INT < 24)) {
             // Debug overrides is enabled and we are on a pre-N device; we need to do it manually
-            baselineTrustManager = DebugOverridesTrustManager.getInstance(debugCaCerts);
+            baselineTrustManager = ExtendedTrustManager.getInstance(trustAnchors);
         }
 
         backgroundReporter = reporter;

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
@@ -1,7 +1,8 @@
 package com.datatheorem.android.trustkit.utils;
 
-
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 
 import java.util.UUID;
 
@@ -18,18 +19,18 @@ public class VendorIdentifier {
 
     @NonNull
     public static String getOrCreate(@NonNull Context appContext) {
-//        SharedPreferences trustKitSharedPreferences =
-//                PreferenceManager.getDefaultSharedPreferences(appContext);
-//        // We store the vendor ID in the App's preferences
-//        String appVendorId = trustKitSharedPreferences.getString(TRUSTKIT_VENDOR_ID, "");
-//        if (appVendorId.equals("")) {
-//            // First time the App is running: generate and store a new vendor ID
-//            TrustKitLog.i("Generating new vendor identifier...");
-//            appVendorId = UUID.randomUUID().toString();
-//            SharedPreferences.Editor editor = trustKitSharedPreferences.edit();
-//            editor.putString(TRUSTKIT_VENDOR_ID, appVendorId);
-//            editor.apply();
-//        }
+        SharedPreferences trustKitSharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(appContext);
+        // We store the vendor ID in the App's preferences
+        String appVendorId = trustKitSharedPreferences.getString(TRUSTKIT_VENDOR_ID, "");
+        if ("".equals(appVendorId)) {
+            // First time the App is running: generate and store a new vendor ID
+            TrustKitLog.i("Generating new vendor identifier...");
+            appVendorId = UUID.randomUUID().toString();
+            SharedPreferences.Editor editor = trustKitSharedPreferences.edit();
+            editor.putString(TRUSTKIT_VENDOR_ID, appVendorId);
+            editor.apply();
+        }
         return UUID.randomUUID().toString();
     }
 }

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
@@ -23,6 +23,11 @@ public class VendorIdentifier {
                 PreferenceManager.getDefaultSharedPreferences(appContext);
         // We store the vendor ID in the App's preferences
         String appVendorId = trustKitSharedPreferences.getString(TRUSTKIT_VENDOR_ID, "");
+        // In case null was stored in preferences we will do this instead of assert to ensure NonNull value
+        if (appVendorId == null) {
+            appVendorId = "";
+        }
+
         if ("".equals(appVendorId)) {
             // First time the App is running: generate and store a new vendor ID
             TrustKitLog.i("Generating new vendor identifier...");
@@ -31,6 +36,6 @@ public class VendorIdentifier {
             editor.putString(TRUSTKIT_VENDOR_ID, appVendorId);
             editor.apply();
         }
-        return UUID.randomUUID().toString();
+        return appVendorId;
     }
 }

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/utils/VendorIdentifier.java
@@ -2,12 +2,10 @@ package com.datatheorem.android.trustkit.utils;
 
 
 import android.content.Context;
-import android.content.SharedPreferences;
-
-import androidx.annotation.NonNull;
-import androidx.preference.PreferenceManager;
 
 import java.util.UUID;
+
+import androidx.annotation.NonNull;
 
 /**
  * When TrustKit sends a report, it also sends a randomly-generated identifier to uniquely identify
@@ -20,18 +18,18 @@ public class VendorIdentifier {
 
     @NonNull
     public static String getOrCreate(@NonNull Context appContext) {
-        SharedPreferences trustKitSharedPreferences =
-                PreferenceManager.getDefaultSharedPreferences(appContext);
-        // We store the vendor ID in the App's preferences
-        String appVendorId = trustKitSharedPreferences.getString(TRUSTKIT_VENDOR_ID, "");
-        if (appVendorId.equals("")) {
-            // First time the App is running: generate and store a new vendor ID
-            TrustKitLog.i("Generating new vendor identifier...");
-            appVendorId = UUID.randomUUID().toString();
-            SharedPreferences.Editor editor = trustKitSharedPreferences.edit();
-            editor.putString(TRUSTKIT_VENDOR_ID, appVendorId);
-            editor.apply();
-        }
-        return appVendorId;
+//        SharedPreferences trustKitSharedPreferences =
+//                PreferenceManager.getDefaultSharedPreferences(appContext);
+//        // We store the vendor ID in the App's preferences
+//        String appVendorId = trustKitSharedPreferences.getString(TRUSTKIT_VENDOR_ID, "");
+//        if (appVendorId.equals("")) {
+//            // First time the App is running: generate and store a new vendor ID
+//            TrustKitLog.i("Generating new vendor identifier...");
+//            appVendorId = UUID.randomUUID().toString();
+//            SharedPreferences.Editor editor = trustKitSharedPreferences.edit();
+//            editor.putString(TRUSTKIT_VENDOR_ID, appVendorId);
+//            editor.apply();
+//        }
+        return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
* Add reading of trust anchors certificates
* Trust anchors cert have the same logic as debug-overrides cert
* Add options to only warn about invalid domain configuration

These changes enables us to use TrustKit to configure a custom domain with self-signed certificate which are commonly used for test environments on the server side. 